### PR TITLE
why a device would get a NSE

### DIFF
--- a/biomede-211-w19.tex
+++ b/biomede-211-w19.tex
@@ -4068,11 +4068,16 @@ Regardless of classification, there exist general controls which apply to all me
 
 \subsection{The ``Safe Medical Devices Act of 1990''}
 \begin{itemize}
-	\item Improved postmarket surveillance of devices by (1) requiring user facilities (such as hospitals and nursing homes) to report adverse events involving medical devices and (2) authorizing the FDA to require manufacturers to perform postmarket surveillance on permanently implanted devices if permanent harm or death could result from device failure.
+	\item Improved postmarket surveillance of devices by (1) requiring user facilities (such as hospitals and nursing homes) to report adverse events involving medical devices and (2) authorizing the FDA to require manufacturers to perform postmarket surveillance on permanently implanted devices if permanent harm or death could result from device failure. Postmarket surveillance is also required when a product is expected to "have significant use in pediatric populations." 
 	\item Authorized the FDA to order device recalls and to impose civil penalties for violations of the The ``Federal Food, Drug, and Cosmetic Act of 1938''.
-	\item Defined substantial equivalence (the standard for marketing a device through the 510(k) program).
+	\item Defined substantial equivalence (the standard for marketing a device through the 510(k) program). Reasons a device could not be considered substantially equivalent to another, as stated by the FDA, include:
+	\subitem No predicate item exists.
+	\subitem The device has a new intended use compared to the identified predicate product.
+	\subitem the device has different technological characteristics that raise different questions of
+safety and effectiveness than the identified predicate device; or
+	\subitem the device has new indications for use or different technological characteristics than the identified predicate device, and required performance data was not provided to allow FDA to reach a substantial equivalence determination. This may include inadequate or inconclusive performance data (e.g., bench testing, clinical data, or animal data).
 	\item Modified procedures for the establishment, amendment, or revocation of performance standards.
-	\item Created the Humanitarian Use Device (HUD)/Humanitarian Device Exemption (HDE) programs to encourage development of devices targeting rare diseases.
+	\item Created the Humanitarian Use Device (HUD)/Humanitarian Device Ex4emption (HDE) programs to encourage development of devices targeting rare diseases.
 \end{itemize}
 
 \subsection{The ``Medical Device Amendments of 1992''}
@@ -4094,7 +4099,7 @@ Regardless of classification, there exist general controls which apply to all me
 	\item Created the option of accredited third parties to conduct initial premarket reviews for certain devices.
 	\item Permitted the use of data from studies of earlier versions of a device in premarket submissions for new versions of the device.
 	\item Provided for expanded access to investigational devices.
-	\item Established the \textit{De Novo} program through which novel low-to-moderate risk devices could be classified into Class I or II instead of automatically classifying them into Class III.
+	\item Established the \textit{De Novo} program through which novel low-to-moderate risk devices could be classified into Class I or II instead of automatically classifying them into Class III. Many products go through the De Novo pathway after failing to get approved via 510(k). 
 \end{itemize}
 
 \subsection{The ``Medical Device User Fee and Modernization Act of 2002''}


### PR DESCRIPTION
"Safe Medical Devices Act of 1990," cited reasons that a device would not get approved via 510(k) pathway.